### PR TITLE
Add deprecation messages onLoad and biocLite

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -2,7 +2,7 @@ Package: BiocInstaller
 Title: Install/Update Bioconductor, CRAN, and github Packages
 Description: This package is used to install and update Bioconductor,
     CRAN, and (some) github packages.
-Version: 1.31.1
+Version: 1.31.2
 Author: Dan Tenenbaum and Biocore Team
 Maintainer: Bioconductor Package Maintainer <maintainer@bioconductor.org>
 biocViews: Infrastructure

--- a/NEWS
+++ b/NEWS
@@ -1,3 +1,16 @@
+CHANGES IN VERSION 1.31.2
+-------------------------
+
+NEW FEATURES
+
+    o 'BiocInstaller' is currently deprecated. All installation of Bioconductor
+    packages will be done via `BiocManager` a CRAN package.
+
+BUG FIXES
+
+    o The documentation incorrectly refered to `remotes::install` which is
+    not an exported function of the package. This link was fixed.
+
 CHANGES IN VERSION 1.30.0
 -------------------------
 

--- a/R/biocLite.R
+++ b/R/biocLite.R
@@ -154,6 +154,7 @@ biocLite <-
              suppressAutoUpdate=FALSE,
              siteRepos=character(), ask=TRUE, ...)
 {
+    .Deprecated("BiocManager::install")
     if (missing(pkgs))   # biocLite() update w/out installing defaults
         pkgs <- pkgs[!pkgs %in% rownames(installed.packages())]
     if (!suppressAutoUpdate && !.isCurrentBiocInstaller()) {

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -71,6 +71,8 @@ globalVariables("repos")           # used in 'bootstrap' functions
 .onLoad <-
     function(libname, pkgname)
 {
+    warning("'BiocInstaller' is currently deprecated, please
+    use the 'BiocManager' CRAN package instead.")
     fl <- system.file(package="BiocInstaller", "scripts",
                       "BiocInstaller.dcf")
     dcf <- read.dcf(fl)

--- a/man/biocLite.Rd
+++ b/man/biocLite.Rd
@@ -70,7 +70,7 @@ biocLite(pkgs=c("Biobase", "IRanges", "AnnotationDbi"),
     When installing github packages, \code{...} is passed to the
     \pkg{remotes} package functions
     \code{\link[remotes]{install_github}} and
-    \code{\link[remotes]{install}}. A typical use is to build vignettes,
+    \code{install} (internally). A typical use is to build vignettes,
     via \code{dependencies=TRUE, build_vignettes=TRUE}.
 
   }


### PR DESCRIPTION
We're deprecating this package. I've added `.Deprecated` in `biocLite` and a `warning` message in `.onLoad`.